### PR TITLE
Update package.json file to include @type/lodash

### DIFF
--- a/tutorials/cloud-iot-firestore-config/functions/package.json
+++ b/tutorials/cloud-iot-firestore-config/functions/package.json
@@ -22,7 +22,8 @@
     "cbor": "^4.0.0",
     "firebase-admin": "^5.12.0",
     "firebase-functions": "^1.0.2",
-    "googleapis": "^27.0.0"
+    "googleapis": "^27.0.0",
+    "@types/lodash": "4.14.121"
   },
   "devDependencies": {
     "gts": "^0.5.4",


### PR DESCRIPTION
While running https://www.qwiklabs.com/focuses/2767?parent=catalog Using Firestore with Cloud IoT Core for Device 
I couldn't pass npm install step without this change.